### PR TITLE
remove the indirection to get at these addresses

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -166,11 +166,10 @@ pub trait Prefix: Eq + std::str::FromStr + std::string::ToString {
     /// ```
     /// # use addrs::ipv4::Prefix;
     /// let prefix = "1.2.3.234/26".parse::<ipnet::Ipv4Net>().unwrap();
-    /// assert_eq!("1.2.3.192/26", Prefix::network(&prefix).to_string());
+    /// assert_eq!("1.2.3.192", Prefix::network(&prefix).to_string());
     /// ```
-    fn network(&self) -> Self {
-        let address = self.address() & self.mask();
-        unsafe { Self::unsafe_new(address, self.length()) }
+    fn network(&self) -> Self::Address {
+        self.address() & self.mask()
     }
 
     /// returns a new Prefix with the network bits zeroed out so that only the bits in the
@@ -183,11 +182,10 @@ pub trait Prefix: Eq + std::str::FromStr + std::string::ToString {
     /// }
     ///
     /// let prefix = "1.2.3.234/26".parse::<ipnet::Ipv4Net>().unwrap();
-    /// assert_eq!("0.0.0.42/26", prefix.host().to_string());
+    /// assert_eq!(42u32, prefix.host().into());
     /// ```
-    fn host(&self) -> Self {
-        let address = self.address() & !self.mask();
-        unsafe { Self::unsafe_new(address, self.length()) }
+    fn host(&self) -> Self::Address {
+        self.address() & !self.mask()
     }
 
     /// returns a new Prefix with all the host bits set to 1s. Note that this method ignores
@@ -198,11 +196,10 @@ pub trait Prefix: Eq + std::str::FromStr + std::string::ToString {
     /// ```
     /// # use addrs::ipv4::Prefix;
     /// let prefix = "1.2.3.1/24".parse::<ipnet::Ipv4Net>().unwrap();
-    /// assert_eq!("1.2.3.255/24", Prefix::broadcast(&prefix).to_string());
+    /// assert_eq!("1.2.3.255", Prefix::broadcast(&prefix).to_string());
     /// ```
-    fn broadcast(&self) -> Self {
-        let address = self.address() | !self.mask();
-        unsafe { Self::unsafe_new(address, self.length()) }
+    fn broadcast(&self) -> Self::Address {
+        self.address() | !self.mask()
     }
 
     /// returns two prefixes that partition this prefix into two equal halves. If the prefix is a

--- a/tests/ipv4_prefix_test.rs
+++ b/tests/ipv4_prefix_test.rs
@@ -65,9 +65,9 @@ runner::tests! { prefix_to_string {
 
 fn prefix_net_host_broadcast(
     prefix: util::Prefix,
-    network: util::Prefix,
-    host: util::Prefix,
-    broadcast: util::Prefix,
+    network: util::Address,
+    host: util::Address,
+    broadcast: util::Address,
 ) {
     assert_eq!(network, Prefix::network(&prefix));
     assert_eq!(host, Prefix::host(&prefix));
@@ -75,10 +75,10 @@ fn prefix_net_host_broadcast(
 }
 
 runner::tests! { prefix_net_host_broadcast {
-    zero( util::p("10.224.24.1/0"), util::p("0.0.0.0/0"), util::p("10.224.24.1/0"), util::p("255.255.255.255/0"));
-    eight( util::p("10.224.24.1/8"), util::p("10.0.0.0/8"), util::p("0.224.24.1/8"), util::p("10.255.255.255/8"));
-    twentytwo( util::p("10.224.24.1/22"), util::p("10.224.24.0/22"), util::p("0.0.0.1/22"), util::p("10.224.27.255/22"));
-    thirtytwo( util::p("10.224.24.1/32"), util::p("10.224.24.1/32"), util::p("0.0.0.0/32"), util::p("10.224.24.1/32"));
+    zero( util::p("10.224.24.1/0"), util::a("0.0.0.0"), util::a("10.224.24.1"), util::a("255.255.255.255"));
+    eight( util::p("10.224.24.1/8"), util::a("10.0.0.0"), util::a("0.224.24.1"), util::a("10.255.255.255"));
+    twentytwo( util::p("10.224.24.1/22"), util::a("10.224.24.0"), util::a("0.0.0.1"), util::a("10.224.27.255"));
+    thirtytwo( util::p("10.224.24.1/32"), util::a("10.224.24.1"), util::a("0.0.0.0"), util::a("10.224.24.1"));
 } }
 
 fn num_addresses(expected: Result<u32>, prefix: util::Prefix) {


### PR DESCRIPTION
At first, I thought it was good to keep the prefix length with these addresses and treat them as prefixes. However, in practice, it is just another step to get an what you want.